### PR TITLE
Do not take singularity from upcoming-development (SOFTWARE-3536)

### DIFF
--- a/genbranches
+++ b/genbranches
@@ -44,15 +44,15 @@ FROM %(from_container)s
 LABEL name="OSG %(series)s Worker Node Client on %(dver_descr)s%(repo_descr)s"
 LABEL build-date="@BUILDDATE@"
 
-RUN yum -y install https://repo.opensciencegrid.org/osg/%(series)s/osg-%(series)s-%(dver)s-release-latest.rpm && \
-    yum -y install epel-release \
+RUN yum -y install https://repo.opensciencegrid.org/osg/%(series)s/osg-%(series)s-%(dver)s-release-latest.rpm \
+                   epel-release \
                    yum-plugin-priorities && \
     yum -y install %(repo_arg)s \
                    osg-wn-client \
                    redhat-lsb-core \
-                   singularity
-
-RUN yum clean all
+                   singularity && \
+    yum clean all && \
+    rm -rf /var/cache/yum/*
 """
 
 branches = {}

--- a/genbranches
+++ b/genbranches
@@ -49,11 +49,10 @@ RUN yum -y install https://repo.opensciencegrid.org/osg/%(series)s/osg-%(series)
                    yum-plugin-priorities && \
     yum -y install %(repo_arg)s \
                    osg-wn-client \
-                   redhat-lsb-core
+                   redhat-lsb-core \
+                   singularity
 
-# Install Singularity
-RUN yum -y install --enablerepo=osg-upcoming-development singularity && \
-    yum clean all
+RUN yum clean all
 """
 
 branches = {}


### PR DESCRIPTION
I tested this with the 3.4-devel docker image at https://cloud.docker.com/u/opensciencegrid/repository/registry-1.docker.io/opensciencegrid/osg-wn; I looked at the build logs and saw that the expected packages were installed. The version of singularity that was installed is 2.6.1-1.1.osg34.el7.

Build logs at https://cloud.docker.com/u/opensciencegrid/repository/registry-1.docker.io/opensciencegrid/osg-wn/builds/be101943-7996-4a6c-96fd-5cf61c04313f (dunno if you have access; the osgsoftware user didn't).